### PR TITLE
FLEEK-138 Allow for root password to be set

### DIFF
--- a/configs/deployment.yml.example
+++ b/configs/deployment.yml.example
@@ -8,6 +8,7 @@ host_cidr: "10.0.60.0/24"                        # Host Management Network CIDR
 obm_cidr: "10.0.50.0/24"                         # Out of Band Management Network CIDR (for DRAC/iLO)
 obm_user: "root"                                 # OBM User
 obm_password: "yoursecretpassword"               # OBM Password
+root_console_password: "yoursecretpassword"      # Sets root password for console login only, not SSH
 primary_nameserver: "8.8.8.8"                    # Primary Nameserver for Environment
 secondary_nameserver: "8.8.4.4"                  # Secondary Nameserver for Environment
 bios_mode: "UEFI"                                # BIOS Mode - UEFI or Legacy, used to pull different OS configs

--- a/playbooks/deploy-pxe.yml
+++ b/playbooks/deploy-pxe.yml
@@ -105,6 +105,11 @@
         path: /var/www/pxe/deploy_key
         mode: 0644
 
+    - name: Generate SHA from root_console_password if set
+      shell: 'printf "{{ root_console_password }}" | mkpasswd -m sha-512 -s'
+      register: root_console_sha
+      when: root_console_password is defined
+
     - name: Generate MAC directories for all systems
       file:
         path: "/var/www/pxe/pxe/{{ item.value.mac | replace(':', '-') | lower }}"

--- a/playbooks/pxe/preseeds/legacy/ubuntu-server-16.04-unattended-rpc-ceph.preseed.j2
+++ b/playbooks/pxe/preseeds/legacy/ubuntu-server-16.04-unattended-rpc-ceph.preseed.j2
@@ -246,7 +246,7 @@ popularity-contest popularity-contest/participate boolean false
 #############
 
 d-i passwd/root-login boolean true
-d-i passwd/root-password-crypted password !!
+d-i passwd/root-password-crypted password {{ root_console_sha.stdout | default('!!') }}
 d-i passwd/make-user boolean false
 
 # The root password is disabled by default. In case you want to use a root

--- a/playbooks/pxe/preseeds/legacy/ubuntu-server-16.04-unattended-rpc-compute.preseed.j2
+++ b/playbooks/pxe/preseeds/legacy/ubuntu-server-16.04-unattended-rpc-compute.preseed.j2
@@ -254,7 +254,7 @@ popularity-contest popularity-contest/participate boolean false
 #############
 
 d-i passwd/root-login boolean true
-d-i passwd/root-password-crypted password !!
+d-i passwd/root-password-crypted password {{ root_console_sha.stdout | default('!!') }}
 d-i passwd/make-user boolean false
 
 # The root password is disabled by default. In case you want to use a root

--- a/playbooks/pxe/preseeds/legacy/ubuntu-server-16.04-unattended-rpc-haproxy.preseed.j2
+++ b/playbooks/pxe/preseeds/legacy/ubuntu-server-16.04-unattended-rpc-haproxy.preseed.j2
@@ -246,7 +246,7 @@ popularity-contest popularity-contest/participate boolean false
 #############
 
 d-i passwd/root-login boolean true
-d-i passwd/root-password-crypted password !!
+d-i passwd/root-password-crypted password {{ root_console_sha.stdout | default('!!') }}
 d-i passwd/make-user boolean false
 
 # The root password is disabled by default. In case you want to use a root

--- a/playbooks/pxe/preseeds/legacy/ubuntu-server-16.04-unattended-rpc-infra.preseed.j2
+++ b/playbooks/pxe/preseeds/legacy/ubuntu-server-16.04-unattended-rpc-infra.preseed.j2
@@ -246,7 +246,7 @@ popularity-contest popularity-contest/participate boolean false
 #############
 
 d-i passwd/root-login boolean true
-d-i passwd/root-password-crypted password !!
+d-i passwd/root-password-crypted password {{ root_console_sha.stdout | default('!!') }}
 d-i passwd/make-user boolean false
 
 # The root password is disabled by default. In case you want to use a root

--- a/playbooks/pxe/preseeds/uefi/ubuntu-server-16.04-unattended-rpc-ceph.preseed.j2
+++ b/playbooks/pxe/preseeds/uefi/ubuntu-server-16.04-unattended-rpc-ceph.preseed.j2
@@ -264,7 +264,7 @@ popularity-contest popularity-contest/participate boolean false
 #############
 
 d-i passwd/root-login boolean true
-d-i passwd/root-password-crypted password !!
+d-i passwd/root-password-crypted password {{ root_console_sha.stdout | default('!!') }}
 d-i passwd/make-user boolean false
 
 # The root password is disabled by default. In case you want to use a root

--- a/playbooks/pxe/preseeds/uefi/ubuntu-server-16.04-unattended-rpc-compute.preseed.j2
+++ b/playbooks/pxe/preseeds/uefi/ubuntu-server-16.04-unattended-rpc-compute.preseed.j2
@@ -272,7 +272,7 @@ popularity-contest popularity-contest/participate boolean false
 #############
 
 d-i passwd/root-login boolean true
-d-i passwd/root-password-crypted password !!
+d-i passwd/root-password-crypted password {{ root_console_sha.stdout | default('!!') }}
 d-i passwd/make-user boolean false
 
 # The root password is disabled by default. In case you want to use a root

--- a/playbooks/pxe/preseeds/uefi/ubuntu-server-16.04-unattended-rpc-haproxy.preseed.j2
+++ b/playbooks/pxe/preseeds/uefi/ubuntu-server-16.04-unattended-rpc-haproxy.preseed.j2
@@ -264,7 +264,7 @@ popularity-contest popularity-contest/participate boolean false
 #############
 
 d-i passwd/root-login boolean true
-d-i passwd/root-password-crypted password !!
+d-i passwd/root-password-crypted password {{ root_console_sha.stdout | default('!!') }}
 d-i passwd/make-user boolean false
 
 # The root password is disabled by default. In case you want to use a root

--- a/playbooks/pxe/preseeds/uefi/ubuntu-server-16.04-unattended-rpc-infra.preseed.j2
+++ b/playbooks/pxe/preseeds/uefi/ubuntu-server-16.04-unattended-rpc-infra.preseed.j2
@@ -264,7 +264,7 @@ popularity-contest popularity-contest/participate boolean false
 #############
 
 d-i passwd/root-login boolean true
-d-i passwd/root-password-crypted password !!
+d-i passwd/root-password-crypted password {{ root_console_sha.stdout | default('!!') }}
 d-i passwd/make-user boolean false
 
 # The root password is disabled by default. In case you want to use a root

--- a/playbooks/vars/ubuntu.yml
+++ b/playbooks/vars/ubuntu.yml
@@ -24,6 +24,7 @@ deploy_host_distro_packages:
   - python-software-properties
   - software-properties-common
   - vlan
+  - whois
 
 deploy_pxe_distro_packages:
   - tftpd-hpa


### PR DESCRIPTION
Sets a password so that the server can be logged in via
console from an Out-Of-Band session.  By default all preseeds
disable root password via SSH and assume you are using keys to
connect via SSH.

Adds whois package for mkpasswd command.